### PR TITLE
fp: Wurth Spacers: fix 3D model orientation relative to footprint

### DIFF
--- a/footprints/4ms_Hardware.pretty/MountingHole_WurthElektronik_WA-SNTI.kicad_mod
+++ b/footprints/4ms_Hardware.pretty/MountingHole_WurthElektronik_WA-SNTI.kicad_mod
@@ -40,8 +40,8 @@
     (rotate (xyz 0 -180 -90))
   )
   (model "${KICAD_4MS_LIBS}/3dmodels/Hardware.3dshapes/MountingHole_WurthElektronik_WA-SNTI.stp"
-    (offset (xyz 0 0 0))
+    (offset (xyz 0 0 8))
     (scale (xyz 1 1 1))
-    (rotate (xyz 0 0 0))
+    (rotate (xyz 0 -180 -90))
   )
 )


### PR DESCRIPTION
3D model orientation was not set for second model path option (pointing to `KICAD_4MS_LIBS`)